### PR TITLE
Specify multiple gateways on PulsarCluster

### DIFF
--- a/cloud/apikey_test.go
+++ b/cloud/apikey_test.go
@@ -157,7 +157,7 @@ resource "streamnative_apikey" "test-terraform-api-key" {
   depends_on = [streamnative_pulsar_cluster.test-api-key-pulsar-cluster]
   organization = "%s"
   name = "%s"
-  instance_name = "terraform-test-api-key-pulsar-instance"
+  instance_name = "%s"
   service_account_name = "terraform-test-api-key-service-account"
   # just for testing, please don't set it to true for avoid token revoked
   revoke = true
@@ -170,5 +170,5 @@ data "streamnative_apikey" "test-terraform-api-key" {
   name = streamnative_apikey.test-terraform-api-key.name
   private_key = streamnative_apikey.test-terraform-api-key.private_key
 }
-`, organization, name, poolName, poolNamespace, organization, name, name, location, releaseChannel, organization, name)
+`, organization, name, poolName, poolNamespace, organization, name, name, location, releaseChannel, organization, name, name)
 }

--- a/cloud/data_source_pulsar_cluster.go
+++ b/cloud/data_source_pulsar_cluster.go
@@ -269,7 +269,7 @@ func dataSourcePulsarClusterRead(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 	_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
-	_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
+	_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
 	_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
 	_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
 	_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))

--- a/cloud/data_source_pulsar_cluster.go
+++ b/cloud/data_source_pulsar_cluster.go
@@ -293,28 +293,27 @@ func dataSourcePulsarClusterRead(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 	}
-	if pulsarCluster.Spec.EndpointAccess != nil {
-		_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
-		_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
-		_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
-		_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
-		_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
+	_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
+	_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
+	_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
+	_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
+	_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
+	if len(httpTlsServiceUrls) > 0 {
+		_ = d.Set("http_tls_service_url", httpTlsServiceUrls[0])
+	}
+	if len(pulsarTlsServiceUrls) > 0 {
+		_ = d.Set("pulsar_tls_service_url", pulsarTlsServiceUrls[0])
+	}
+	if len(websocketServiceUrls) > 0 {
+		_ = d.Set("websocket_service_url", websocketServiceUrls[0])
+	}
+	if len(kafkaServiceUrls) > 0 {
+		_ = d.Set("kafka_service_url", kafkaServiceUrls[0])
+	}
+	if len(mqttServiceUrls) > 0 {
+		_ = d.Set("mqtt_service_url", mqttServiceUrls[0])
 	} else {
-		if len(httpTlsServiceUrls) > 0 {
-			_ = d.Set("http_tls_service_url", httpTlsServiceUrls[0])
-		}
-		if len(pulsarTlsServiceUrls) > 0 {
-			_ = d.Set("pulsar_tls_service_url", pulsarTlsServiceUrls[0])
-		}
-		if len(websocketServiceUrls) > 0 {
-			_ = d.Set("websocket_service_url", websocketServiceUrls[0])
-		}
-		if len(kafkaServiceUrls) > 0 {
-			_ = d.Set("kafka_service_url", kafkaServiceUrls[0])
-		}
-		if len(mqttServiceUrls) > 0 {
-			_ = d.Set("mqtt_service_url", mqttServiceUrls[0])
-		}
+		_ = d.Set("mqtt_service_url", "")
 	}
 	if pulsarCluster.Spec.Config != nil {
 		err = d.Set("config", flattenPulsarClusterConfig(pulsarCluster.Spec.Config))

--- a/cloud/data_source_pulsar_cluster.go
+++ b/cloud/data_source_pulsar_cluster.go
@@ -160,6 +160,11 @@ func dataSourcePulsarCluster() *schema.Resource {
 				Computed:    true,
 				Description: descriptions["cluster_ready"],
 			},
+			"http_tls_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["http_tls_service_url"],
+			},
 			"http_tls_service_urls": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -167,6 +172,11 @@ func dataSourcePulsarCluster() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"pulsar_tls_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["pulsar_tls_service_url"],
 			},
 			"pulsar_tls_service_urls": {
 				Type:        schema.TypeList,
@@ -176,6 +186,11 @@ func dataSourcePulsarCluster() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"kafka_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["kafka_service_url"],
+			},
 			"kafka_service_urls": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -184,6 +199,11 @@ func dataSourcePulsarCluster() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"mqtt_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["mqtt_service_url"],
+			},
 			"mqtt_service_urls": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -191,6 +211,11 @@ func dataSourcePulsarCluster() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"websocket_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["websocket_service_url"],
 			},
 			"websocket_service_urls": {
 				Type:        schema.TypeList,
@@ -268,12 +293,29 @@ func dataSourcePulsarClusterRead(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 	}
-	_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
-	_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
-	_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
-	_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
-	_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
-
+	if pulsarCluster.Spec.EndpointAccess != nil {
+		_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
+		_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
+		_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
+		_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
+		_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
+	} else {
+		if len(httpTlsServiceUrls) > 0 {
+			_ = d.Set("http_tls_service_url", httpTlsServiceUrls[0])
+		}
+		if len(pulsarTlsServiceUrls) > 0 {
+			_ = d.Set("pulsar_tls_service_url", pulsarTlsServiceUrls[0])
+		}
+		if len(websocketServiceUrls) > 0 {
+			_ = d.Set("websocket_service_url", websocketServiceUrls[0])
+		}
+		if len(kafkaServiceUrls) > 0 {
+			_ = d.Set("kafka_service_url", kafkaServiceUrls[0])
+		}
+		if len(mqttServiceUrls) > 0 {
+			_ = d.Set("mqtt_service_url", mqttServiceUrls[0])
+		}
+	}
 	if pulsarCluster.Spec.Config != nil {
 		err = d.Set("config", flattenPulsarClusterConfig(pulsarCluster.Spec.Config))
 		if err != nil {

--- a/cloud/data_source_pulsar_cluster.go
+++ b/cloud/data_source_pulsar_cluster.go
@@ -24,6 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	IstioEnabledAnnotation = "annotations.cloud.streamnative.io/istio-enabled"
+)
+
 func dataSourcePulsarCluster() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourcePulsarClusterRead,
@@ -156,30 +160,45 @@ func dataSourcePulsarCluster() *schema.Resource {
 				Computed:    true,
 				Description: descriptions["cluster_ready"],
 			},
-			"http_tls_service_url": {
-				Type:        schema.TypeString,
+			"http_tls_service_urls": {
+				Type:        schema.TypeList,
 				Computed:    true,
-				Description: descriptions["http_tls_service_url"],
+				Description: descriptions["http_tls_service_urls"],
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
-			"pulsar_tls_service_url": {
-				Type:        schema.TypeString,
+			"pulsar_tls_service_urls": {
+				Type:        schema.TypeList,
 				Computed:    true,
-				Description: descriptions["pulsar_tls_service_url"],
+				Description: descriptions["pulsar_tls_service_urls"],
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
-			"kafka_service_url": {
-				Type:        schema.TypeString,
+			"kafka_service_urls": {
+				Type:        schema.TypeList,
 				Computed:    true,
-				Description: descriptions["kafka_service_url"],
+				Description: descriptions["kafka_service_urls"],
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
-			"mqtt_service_url": {
-				Type:        schema.TypeString,
+			"mqtt_service_urls": {
+				Type:        schema.TypeList,
 				Computed:    true,
-				Description: descriptions["mqtt_service_url"],
+				Description: descriptions["mqtt_service_urls"],
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
-			"websocket_service_url": {
-				Type:        schema.TypeString,
+			"websocket_service_urls": {
+				Type:        schema.TypeList,
 				Computed:    true,
-				Description: descriptions["websocket_service_url"],
+				Description: descriptions["websocket_service_urls"],
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"pulsar_version": {
 				Type:        schema.TypeString,
@@ -214,25 +233,47 @@ func dataSourcePulsarClusterRead(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 	}
-	if len(pulsarCluster.Spec.ServiceEndpoints) > 0 {
-		dnsName := pulsarCluster.Spec.ServiceEndpoints[0].DnsName
-		_ = d.Set("http_tls_service_url", fmt.Sprintf("https://%s", dnsName))
-		_ = d.Set("pulsar_tls_service_url", fmt.Sprintf("pulsar+ssl://%s:6651", dnsName))
-		if pulsarCluster.Spec.Config != nil {
-			if pulsarCluster.Spec.Config.WebsocketEnabled != nil &&
-				*pulsarCluster.Spec.Config.WebsocketEnabled {
-				_ = d.Set("websocket_service_url", fmt.Sprintf("wss://%s:9443", dnsName))
-			}
-			if pulsarCluster.Spec.Config.Protocols != nil {
-				if pulsarCluster.Spec.Config.Protocols.Kafka != nil {
-					_ = d.Set("kafka_service_url", fmt.Sprintf("%s:9093", dnsName))
+	pulsarInstance, err := clientSet.CloudV1alpha1().PulsarInstances(namespace).Get(ctx, pulsarCluster.Spec.InstanceName, metav1.GetOptions{})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("ERROR_READ_PULSAR_INSTANCE: %w", err))
+	}
+	istioEnabledVal, ok := pulsarInstance.Annotations[IstioEnabledAnnotation]
+	istioEnabled := ok && istioEnabledVal == "true"
+
+	var httpTlsServiceUrls []string
+	var pulsarTlsServiceUrls []string
+	var websocketServiceUrls []string
+	var kafkaServiceUrls []string
+	var mqttServiceUrls []string
+	for _, endpoint := range pulsarCluster.Spec.ServiceEndpoints {
+		if endpoint.Type == "service" {
+			httpTlsServiceUrls = append(httpTlsServiceUrls, fmt.Sprintf("https://%s", endpoint.DnsName))
+			pulsarTlsServiceUrls = append(pulsarTlsServiceUrls, fmt.Sprintf("pulsar+ssl://%s:6651", endpoint.DnsName))
+			if pulsarCluster.Spec.Config != nil {
+				if pulsarCluster.Spec.Config.WebsocketEnabled != nil && *pulsarCluster.Spec.Config.WebsocketEnabled {
+					if istioEnabled {
+						websocketServiceUrls = append(websocketServiceUrls, fmt.Sprintf("wss://%s", endpoint.DnsName))
+					} else {
+						websocketServiceUrls = append(websocketServiceUrls, fmt.Sprintf("ws://%s:9443", endpoint.DnsName))
+					}
 				}
-				if pulsarCluster.Spec.Config.Protocols.Mqtt != nil {
-					_ = d.Set("mqtt_service_url", fmt.Sprintf("mqtts://%s:8883", dnsName))
+				if pulsarCluster.Spec.Config.Protocols != nil {
+					if pulsarCluster.Spec.Config.Protocols.Kafka != nil && istioEnabled {
+						kafkaServiceUrls = append(kafkaServiceUrls, fmt.Sprintf("%s:9093", endpoint.DnsName))
+					}
+					if pulsarCluster.Spec.Config.Protocols.Mqtt != nil {
+						mqttServiceUrls = append(mqttServiceUrls, fmt.Sprintf("mqtts://%s:8883", endpoint.DnsName))
+					}
 				}
 			}
 		}
 	}
+	_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
+	_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
+	_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
+	_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
+	_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
+
 	if pulsarCluster.Spec.Config != nil {
 		err = d.Set("config", flattenPulsarClusterConfig(pulsarCluster.Spec.Config))
 		if err != nil {

--- a/cloud/gateway_helper.go
+++ b/cloud/gateway_helper.go
@@ -42,6 +42,20 @@ func flattenDefaultGateway(in *cloudv1alpha1.Gateway) []interface{} {
 	return []interface{}{att}
 }
 
+func convertEndpointAccess(val interface{}) []cloudv1alpha1.EndpointAccess {
+	raw := val.([]interface{})
+	var endpointAccess []cloudv1alpha1.EndpointAccess
+	for _, rawItem := range raw {
+		rawItemMap, ok := rawItem.(map[string]interface{})
+		if ok && rawItemMap["gateway"] != "" {
+			endpointAccess = append(endpointAccess, cloudv1alpha1.EndpointAccess{
+				Gateway: rawItemMap["gateway"].(string),
+			})
+		}
+	}
+	return endpointAccess
+}
+
 func convertGateway(val interface{}) *cloudv1alpha1.Gateway {
 	gatewayRaw := val.([]interface{})
 	if len(gatewayRaw) > 0 {

--- a/cloud/gateway_helper.go
+++ b/cloud/gateway_helper.go
@@ -59,7 +59,7 @@ func convertEndpointAccess(val interface{}) []cloudv1alpha1.EndpointAccess {
 func convertGateway(val interface{}) *cloudv1alpha1.Gateway {
 	gatewayRaw := val.([]interface{})
 	if len(gatewayRaw) > 0 {
-		defaultGatewayItemMap, ok := gatewayRaw[0].(map[string]interface{})
+		defaultGatewayItemMap := gatewayRaw[0].(map[string]interface{})
 		var gateway cloudv1alpha1.Gateway
 		access, ok := defaultGatewayItemMap["access"]
 		if ok && access != "" {

--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -91,14 +91,22 @@ func init() {
 		"categories": "Controls the audit log categories config of pulsar cluster, supported categories: " +
 			"\"Management\", \"Describe\", \"Produce\", \"Consume\"",
 		"custom":                  "Controls the custom config of pulsar cluster",
+		"http_tls_service_url":    "The service url of the pulsar cluster, use it to management the pulsar cluster.",
 		"http_tls_service_urls":   "The service url of the pulsar cluster, use it to management the pulsar cluster. There'll be multiple service urls if the cluster attached with multiple gateways",
+		"pulsar_tls_service_url":  "The service url of the pulsar cluster, use it to produce and consume message.",
 		"pulsar_tls_service_urls": "The service url of the pulsar cluster, use it to produce and consume message. There'll be multiple service urls if the cluster attached with multiple gateways",
+		"kafka_service_url": "If you want to connect to the pulsar cluster using the kafka protocol," +
+			" use this kafka service url.",
 		"kafka_service_urls": "If you want to connect to the pulsar cluster using the kafka protocol," +
-			" use this kafka service url.  There'll be multiple service urls if the cluster attached with multiple gateways",
+			" use this kafka service url. There'll be multiple service urls if the cluster attached with multiple gateways",
+		"mqtt_service_url": "If you want to connect to the pulsar cluster using the mqtt protocol, " +
+			"use this mqtt service url.",
 		"mqtt_service_urls": "If you want to connect to the pulsar cluster using the mqtt protocol, " +
 			"use this mqtt service url.  There'll be multiple service urls if the cluster attached with multiple gateways",
+		"websocket_service_url": "If you want to connect to the pulsar cluster using the websocket protocol, " +
+			"use this websocket service url.",
 		"websocket_service_urls": "If you want to connect to the pulsar cluster using the websocket protocol, " +
-			"use this websocket service url.  There'll be multiple service urls if the cluster attached with multiple gateways",
+			"use this websocket service url. There'll be multiple service urls if the cluster attached with multiple gateways",
 		"pulsar_version":         "The version of the pulsar cluster",
 		"bookkeeper_version":     "The version of the bookkeeper cluster",
 		"type":                   "Type of cloud connection, one of aws or gcp",

--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -91,14 +91,14 @@ func init() {
 		"categories": "Controls the audit log categories config of pulsar cluster, supported categories: " +
 			"\"Management\", \"Describe\", \"Produce\", \"Consume\"",
 		"custom":                  "Controls the custom config of pulsar cluster",
-		"http_tls_service_urls":   "The service url of the pulsar cluster, use it to management the pulsar cluster",
-		"pulsar_tls_service_urls": "The service url of the pulsar cluster, use it to produce and consume message",
+		"http_tls_service_urls":   "The service url of the pulsar cluster, use it to management the pulsar cluster. There'll be multiple service urls if the cluster attached with multiple gateways",
+		"pulsar_tls_service_urls": "The service url of the pulsar cluster, use it to produce and consume message. There'll be multiple service urls if the cluster attached with multiple gateways",
 		"kafka_service_urls": "If you want to connect to the pulsar cluster using the kafka protocol," +
-			" use this kafka service url",
+			" use this kafka service url.  There'll be multiple service urls if the cluster attached with multiple gateways",
 		"mqtt_service_urls": "If you want to connect to the pulsar cluster using the mqtt protocol, " +
-			"use this mqtt service url",
+			"use this mqtt service url.  There'll be multiple service urls if the cluster attached with multiple gateways",
 		"websocket_service_urls": "If you want to connect to the pulsar cluster using the websocket protocol, " +
-			"use this websocket service url",
+			"use this websocket service url.  There'll be multiple service urls if the cluster attached with multiple gateways",
 		"pulsar_version":         "The version of the pulsar cluster",
 		"bookkeeper_version":     "The version of the bookkeeper cluster",
 		"type":                   "Type of cloud connection, one of aws or gcp",

--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -90,14 +90,14 @@ func init() {
 		"mqtt":                "Controls the mqtt protocol config of pulsar cluster",
 		"categories": "Controls the audit log categories config of pulsar cluster, supported categories: " +
 			"\"Management\", \"Describe\", \"Produce\", \"Consume\"",
-		"custom":                 "Controls the custom config of pulsar cluster",
-		"http_tls_service_url":   "The service url of the pulsar cluster, use it to management the pulsar cluster",
-		"pulsar_tls_service_url": "The service url of the pulsar cluster, use it to produce and consume message",
-		"kafka_service_url": "If you want to connect to the pulsar cluster using the kafka protocol," +
+		"custom":                  "Controls the custom config of pulsar cluster",
+		"http_tls_service_urls":   "The service url of the pulsar cluster, use it to management the pulsar cluster",
+		"pulsar_tls_service_urls": "The service url of the pulsar cluster, use it to produce and consume message",
+		"kafka_service_urls": "If you want to connect to the pulsar cluster using the kafka protocol," +
 			" use this kafka service url",
-		"mqtt_service_url": "If you want to connect to the pulsar cluster using the mqtt protocol, " +
+		"mqtt_service_urls": "If you want to connect to the pulsar cluster using the mqtt protocol, " +
 			"use this mqtt service url",
-		"websocket_service_url": "If you want to connect to the pulsar cluster using the websocket protocol, " +
+		"websocket_service_urls": "If you want to connect to the pulsar cluster using the websocket protocol, " +
 			"use this websocket service url",
 		"pulsar_version":         "The version of the pulsar cluster",
 		"bookkeeper_version":     "The version of the bookkeeper cluster",

--- a/cloud/resource_pulsar_cluster.go
+++ b/cloud/resource_pulsar_cluster.go
@@ -486,28 +486,27 @@ func resourcePulsarClusterRead(ctx context.Context, d *schema.ResourceData, meta
 			}
 		}
 	}
-	if pulsarCluster.Spec.EndpointAccess != nil {
-		_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
-		_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
-		_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
-		_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
-		_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
+	_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
+	_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
+	_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
+	_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
+	_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
+	if len(httpTlsServiceUrls) > 0 {
+		_ = d.Set("http_tls_service_url", httpTlsServiceUrls[0])
+	}
+	if len(pulsarTlsServiceUrls) > 0 {
+		_ = d.Set("pulsar_tls_service_url", pulsarTlsServiceUrls[0])
+	}
+	if len(websocketServiceUrls) > 0 {
+		_ = d.Set("websocket_service_url", websocketServiceUrls[0])
+	}
+	if len(kafkaServiceUrls) > 0 {
+		_ = d.Set("kafka_service_url", kafkaServiceUrls[0])
+	}
+	if len(mqttServiceUrls) > 0 {
+		_ = d.Set("mqtt_service_url", mqttServiceUrls[0])
 	} else {
-		if len(httpTlsServiceUrls) > 0 {
-			_ = d.Set("http_tls_service_url", httpTlsServiceUrls[0])
-		}
-		if len(pulsarTlsServiceUrls) > 0 {
-			_ = d.Set("pulsar_tls_service_url", pulsarTlsServiceUrls[0])
-		}
-		if len(websocketServiceUrls) > 0 {
-			_ = d.Set("websocket_service_url", websocketServiceUrls[0])
-		}
-		if len(kafkaServiceUrls) > 0 {
-			_ = d.Set("kafka_service_url", kafkaServiceUrls[0])
-		}
-		if len(mqttServiceUrls) > 0 {
-			_ = d.Set("mqtt_service_url", mqttServiceUrls[0])
-		}
+		_ = d.Set("mqtt_service_url", "")
 	}
 	if pulsarCluster.Spec.Config != nil {
 		err = d.Set("config", flattenPulsarClusterConfig(pulsarCluster.Spec.Config))

--- a/cloud/resource_pulsar_cluster.go
+++ b/cloud/resource_pulsar_cluster.go
@@ -215,6 +215,11 @@ func resourcePulsarCluster() *schema.Resource {
 				Computed:    true,
 				Description: descriptions["cluster_ready"],
 			},
+			"http_tls_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["http_tls_service_url"],
+			},
 			"http_tls_service_urls": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -222,6 +227,11 @@ func resourcePulsarCluster() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"pulsar_tls_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["pulsar_tls_service_url"],
 			},
 			"pulsar_tls_service_urls": {
 				Type:        schema.TypeList,
@@ -231,6 +241,11 @@ func resourcePulsarCluster() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"kafka_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["kafka_service_url"],
+			},
 			"kafka_service_urls": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -239,6 +254,11 @@ func resourcePulsarCluster() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"mqtt_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["mqtt_service_url"],
+			},
 			"mqtt_service_urls": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -246,6 +266,11 @@ func resourcePulsarCluster() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"websocket_service_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["websocket_service_url"],
 			},
 			"websocket_service_urls": {
 				Type:        schema.TypeList,
@@ -461,11 +486,29 @@ func resourcePulsarClusterRead(ctx context.Context, d *schema.ResourceData, meta
 			}
 		}
 	}
-	_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
-	_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
-	_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
-	_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
-	_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
+	if pulsarCluster.Spec.EndpointAccess != nil {
+		_ = d.Set("http_tls_service_urls", flattenStringSlice(httpTlsServiceUrls))
+		_ = d.Set("pulsar_tls_service_urls", flattenStringSlice(pulsarTlsServiceUrls))
+		_ = d.Set("websocket_service_urls", flattenStringSlice(websocketServiceUrls))
+		_ = d.Set("kafka_service_urls", flattenStringSlice(kafkaServiceUrls))
+		_ = d.Set("mqtt_service_urls", flattenStringSlice(mqttServiceUrls))
+	} else {
+		if len(httpTlsServiceUrls) > 0 {
+			_ = d.Set("http_tls_service_url", httpTlsServiceUrls[0])
+		}
+		if len(pulsarTlsServiceUrls) > 0 {
+			_ = d.Set("pulsar_tls_service_url", pulsarTlsServiceUrls[0])
+		}
+		if len(websocketServiceUrls) > 0 {
+			_ = d.Set("websocket_service_url", websocketServiceUrls[0])
+		}
+		if len(kafkaServiceUrls) > 0 {
+			_ = d.Set("kafka_service_url", kafkaServiceUrls[0])
+		}
+		if len(mqttServiceUrls) > 0 {
+			_ = d.Set("mqtt_service_url", mqttServiceUrls[0])
+		}
+	}
 	if pulsarCluster.Spec.Config != nil {
 		err = d.Set("config", flattenPulsarClusterConfig(pulsarCluster.Spec.Config))
 		if err != nil {

--- a/docs/data-sources/pulsar_cluster.md
+++ b/docs/data-sources/pulsar_cluster.md
@@ -27,18 +27,23 @@ description: |-
 - `broker_replicas` (Number) The number of broker replicas
 - `compute_unit` (Number) compute unit, 1 compute unit is 2 cpu and 8gb memory
 - `config` (List of Object) (see [below for nested schema](#nestedatt--config))
+- `http_tls_service_url` (String) The service url of the pulsar cluster, use it to management the pulsar cluster.
 - `http_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to management the pulsar cluster. There'll be multiple service urls if the cluster attached with multiple gateways
 - `id` (String) The ID of this resource.
 - `instance_name` (String) The pulsar instance name
-- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `kafka_service_url` (String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url.
+- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url. There'll be multiple service urls if the cluster attached with multiple gateways
 - `location` (String) The location of the pulsar cluster, supported location https://docs.streamnative.io/docs/cluster#cluster-location
+- `mqtt_service_url` (String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url.
 - `mqtt_service_urls` (List of String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `pulsar_tls_service_url` (String) The service url of the pulsar cluster, use it to produce and consume message.
 - `pulsar_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to produce and consume message. There'll be multiple service urls if the cluster attached with multiple gateways
 - `pulsar_version` (String) The version of the pulsar cluster
 - `ready` (String) Pulsar cluster is ready, it will be set to 'True' after the cluster is ready
 - `release_channel` (String) The release channel of the pulsar cluster subscribe to, it must to be lts or rapid, default rapid
 - `storage_unit` (Number) storage unit, 1 storage unit is 2 cpu and 8gb memory
-- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `websocket_service_url` (String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url.
+- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url. There'll be multiple service urls if the cluster attached with multiple gateways
 
 <a id="nestedatt--config"></a>
 ### Nested Schema for `config`

--- a/docs/data-sources/pulsar_cluster.md
+++ b/docs/data-sources/pulsar_cluster.md
@@ -27,18 +27,18 @@ description: |-
 - `broker_replicas` (Number) The number of broker replicas
 - `compute_unit` (Number) compute unit, 1 compute unit is 2 cpu and 8gb memory
 - `config` (List of Object) (see [below for nested schema](#nestedatt--config))
-- `http_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to management the pulsar cluster
+- `http_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to management the pulsar cluster. There'll be multiple service urls if the cluster attached with multiple gateways
 - `id` (String) The ID of this resource.
 - `instance_name` (String) The pulsar instance name
-- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url
+- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url.  There'll be multiple service urls if the cluster attached with multiple gateways
 - `location` (String) The location of the pulsar cluster, supported location https://docs.streamnative.io/docs/cluster#cluster-location
-- `mqtt_service_urls` (List of String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url
-- `pulsar_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to produce and consume message
+- `mqtt_service_urls` (List of String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `pulsar_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to produce and consume message. There'll be multiple service urls if the cluster attached with multiple gateways
 - `pulsar_version` (String) The version of the pulsar cluster
 - `ready` (String) Pulsar cluster is ready, it will be set to 'True' after the cluster is ready
 - `release_channel` (String) The release channel of the pulsar cluster subscribe to, it must to be lts or rapid, default rapid
 - `storage_unit` (Number) storage unit, 1 storage unit is 2 cpu and 8gb memory
-- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url
+- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url.  There'll be multiple service urls if the cluster attached with multiple gateways
 
 <a id="nestedatt--config"></a>
 ### Nested Schema for `config`

--- a/docs/data-sources/pulsar_cluster.md
+++ b/docs/data-sources/pulsar_cluster.md
@@ -27,18 +27,18 @@ description: |-
 - `broker_replicas` (Number) The number of broker replicas
 - `compute_unit` (Number) compute unit, 1 compute unit is 2 cpu and 8gb memory
 - `config` (List of Object) (see [below for nested schema](#nestedatt--config))
-- `http_tls_service_url` (String) The service url of the pulsar cluster, use it to management the pulsar cluster
+- `http_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to management the pulsar cluster
 - `id` (String) The ID of this resource.
 - `instance_name` (String) The pulsar instance name
-- `kafka_service_url` (String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url
+- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url
 - `location` (String) The location of the pulsar cluster, supported location https://docs.streamnative.io/docs/cluster#cluster-location
-- `mqtt_service_url` (String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url
-- `pulsar_tls_service_url` (String) The service url of the pulsar cluster, use it to produce and consume message
+- `mqtt_service_urls` (List of String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url
+- `pulsar_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to produce and consume message
 - `pulsar_version` (String) The version of the pulsar cluster
 - `ready` (String) Pulsar cluster is ready, it will be set to 'True' after the cluster is ready
 - `release_channel` (String) The release channel of the pulsar cluster subscribe to, it must to be lts or rapid, default rapid
 - `storage_unit` (Number) storage unit, 1 storage unit is 2 cpu and 8gb memory
-- `websocket_service_url` (String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url
+- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url
 
 <a id="nestedatt--config"></a>
 ### Nested Schema for `config`

--- a/docs/resources/cloud_environment.md
+++ b/docs/resources/cloud_environment.md
@@ -40,7 +40,10 @@ description: |-
 Optional:
 
 - `cidr` (String)
-- `id` (String)
+
+Read-Only:
+
+- `id` (String) The ID of this resource.
 
 
 <a id="nestedblock--default_gateway"></a>

--- a/docs/resources/cloud_environment.md
+++ b/docs/resources/cloud_environment.md
@@ -40,10 +40,7 @@ description: |-
 Optional:
 
 - `cidr` (String)
-
-Read-Only:
-
-- `id` (String) The ID of this resource.
+- `id` (String)
 
 
 <a id="nestedblock--default_gateway"></a>

--- a/docs/resources/pulsar_cluster.md
+++ b/docs/resources/pulsar_cluster.md
@@ -27,6 +27,7 @@ description: |-
 - `broker_replicas` (Number) The number of broker replicas
 - `compute_unit` (Number) compute unit, 1 compute unit is 2 cpu and 8gb memory
 - `config` (Block List) (see [below for nested schema](#nestedblock--config))
+- `endpoint_access` (Block List) (see [below for nested schema](#nestedblock--endpoint_access))
 - `location` (String) The location of the pulsar cluster, supported location https://docs.streamnative.io/docs/cluster#cluster-location
 - `pool_member_name` (String) The infrastructure pool member name
 - `release_channel` (String) The release channel of the pulsar cluster subscribe to, it must to be lts or rapid, default rapid
@@ -35,14 +36,14 @@ description: |-
 ### Read-Only
 
 - `bookkeeper_version` (String) The version of the bookkeeper cluster
-- `http_tls_service_url` (String) The service url of the pulsar cluster, use it to management the pulsar cluster
+- `http_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to management the pulsar cluster
 - `id` (String) The ID of this resource.
-- `kafka_service_url` (String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url
-- `mqtt_service_url` (String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url
-- `pulsar_tls_service_url` (String) The service url of the pulsar cluster, use it to produce and consume message
+- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url
+- `mqtt_service_urls` (List of String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url
+- `pulsar_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to produce and consume message
 - `pulsar_version` (String) The version of the pulsar cluster
 - `ready` (String) Pulsar cluster is ready, it will be set to 'True' after the cluster is ready
-- `websocket_service_url` (String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url
+- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url
 
 <a id="nestedblock--config"></a>
 ### Nested Schema for `config`
@@ -71,3 +72,12 @@ Optional:
 
 - `kafka` (Map of String) Controls the kafka protocol config of pulsar cluster
 - `mqtt` (Map of String) Controls the mqtt protocol config of pulsar cluster
+
+
+
+<a id="nestedblock--endpoint_access"></a>
+### Nested Schema for `endpoint_access`
+
+Optional:
+
+- `gateway` (String)

--- a/docs/resources/pulsar_cluster.md
+++ b/docs/resources/pulsar_cluster.md
@@ -36,14 +36,19 @@ description: |-
 ### Read-Only
 
 - `bookkeeper_version` (String) The version of the bookkeeper cluster
+- `http_tls_service_url` (String) The service url of the pulsar cluster, use it to management the pulsar cluster.
 - `http_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to management the pulsar cluster. There'll be multiple service urls if the cluster attached with multiple gateways
 - `id` (String) The ID of this resource.
-- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `kafka_service_url` (String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url.
+- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url. There'll be multiple service urls if the cluster attached with multiple gateways
+- `mqtt_service_url` (String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url.
 - `mqtt_service_urls` (List of String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `pulsar_tls_service_url` (String) The service url of the pulsar cluster, use it to produce and consume message.
 - `pulsar_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to produce and consume message. There'll be multiple service urls if the cluster attached with multiple gateways
 - `pulsar_version` (String) The version of the pulsar cluster
 - `ready` (String) Pulsar cluster is ready, it will be set to 'True' after the cluster is ready
-- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `websocket_service_url` (String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url.
+- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url. There'll be multiple service urls if the cluster attached with multiple gateways
 
 <a id="nestedblock--config"></a>
 ### Nested Schema for `config`

--- a/docs/resources/pulsar_cluster.md
+++ b/docs/resources/pulsar_cluster.md
@@ -36,14 +36,14 @@ description: |-
 ### Read-Only
 
 - `bookkeeper_version` (String) The version of the bookkeeper cluster
-- `http_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to management the pulsar cluster
+- `http_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to management the pulsar cluster. There'll be multiple service urls if the cluster attached with multiple gateways
 - `id` (String) The ID of this resource.
-- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url
-- `mqtt_service_urls` (List of String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url
-- `pulsar_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to produce and consume message
+- `kafka_service_urls` (List of String) If you want to connect to the pulsar cluster using the kafka protocol, use this kafka service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `mqtt_service_urls` (List of String) If you want to connect to the pulsar cluster using the mqtt protocol, use this mqtt service url.  There'll be multiple service urls if the cluster attached with multiple gateways
+- `pulsar_tls_service_urls` (List of String) The service url of the pulsar cluster, use it to produce and consume message. There'll be multiple service urls if the cluster attached with multiple gateways
 - `pulsar_version` (String) The version of the pulsar cluster
 - `ready` (String) Pulsar cluster is ready, it will be set to 'True' after the cluster is ready
-- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url
+- `websocket_service_urls` (List of String) If you want to connect to the pulsar cluster using the websocket protocol, use this websocket service url.  There'll be multiple service urls if the cluster attached with multiple gateways
 
 <a id="nestedblock--config"></a>
 ### Nested Schema for `config`


### PR DESCRIPTION
```hcl
resource "streamnative_pulsar_cluster" "test" {
  organization = "sndev"
  name = "test"
  instance_name = "instance-name"
  pool_member_name = "pm-name"
  location = "us-west1"
  config {
    websocket_enabled = true
    protocols {
      kafka = {
        enabled = true
      }
      mqtt = {
        enabled = false
      }
    }
  }
  endpoint_access {
    gateway = "public"
  }
  endpoint_access {
    gateway = "private"
  }
}
```