### PR TITLE
provide pulsar cluster to `ServiceAccountBinding` instead of poolmember, expose oauth2 status to `PulsarInstance`

### DIFF
--- a/cloud/data_source_pulsar_instance.go
+++ b/cloud/data_source_pulsar_instance.go
@@ -75,6 +75,16 @@ func dataSourcePulsarInstance() *schema.Resource {
 				Computed:    true,
 				Description: descriptions["instance_ready"],
 			},
+			"oauth2_audience": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["oauth2_audience"],
+			},
+			"oauth2_issuer_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["oauth2_issuer_url"],
+			},
 		},
 	}
 }
@@ -103,6 +113,11 @@ func dataSourcePulsarInstanceRead(ctx context.Context, d *schema.ResourceData, m
 		_ = d.Set("pool_namespace", pulsarInstance.Spec.PoolRef.Namespace)
 	}
 	_ = d.Set("availability_mode", pulsarInstance.Spec.AvailabilityMode)
+	if pulsarInstance.Status.Auth != nil && pulsarInstance.Status.Auth.Type == "oauth2" &&
+		pulsarInstance.Status.Auth.OAuth2 != nil {
+		_ = d.Set("oauth2_audience", pulsarInstance.Status.Auth.OAuth2.Audience)
+		_ = d.Set("oauth2_issuer_url", pulsarInstance.Status.Auth.OAuth2.IssuerURL)
+	}
 	d.SetId(fmt.Sprintf("%s/%s", pulsarInstance.Namespace, pulsarInstance.Name))
 	return nil
 }

--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -156,6 +156,8 @@ func init() {
 		"default_gateway_private_service_ids": "The private service ids are ids are service names of PrivateLink in AWS, " +
 			"the ids of Private Service Attachment in GCP, " +
 			"and the aliases of PrivateLinkService in Azure.",
+		"oauth2_issuer_url": "The issuer url of the oauth2",
+		"oauth2_audience":   "The audience of the oauth2",
 	}
 }
 

--- a/cloud/pulsar_cluster_test.go
+++ b/cloud/pulsar_cluster_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var clusterGeneratedName = fmt.Sprintf("terraform-test-pulsar-cluster-%d", rand.Intn(10000))
+var clusterGeneratedName = fmt.Sprintf("terraform-test-cluster-%d-%d", rand.Intn(10000), rand.Intn(10000))
 
 func TestPulsarCluster(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/cloud/resource_service_account_binding.go
+++ b/cloud/resource_service_account_binding.go
@@ -80,15 +80,20 @@ func resourceServiceAccountBinding() *schema.Resource {
 				Description:  descriptions["service_account_name"],
 				ValidateFunc: validateNotBlank,
 			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: descriptions["cluster_name"],
+			},
 			"pool_member_name": {
 				Type:        schema.TypeString,
 				Description: descriptions["pool_member_name"],
-				Required:    true,
+				Computed:    true,
 			},
 			"pool_member_namespace": {
 				Type:        schema.TypeString,
 				Description: descriptions["pool_member_namespace"],
-				Required:    true,
+				Computed:    true,
 			},
 		},
 	}
@@ -97,12 +102,21 @@ func resourceServiceAccountBinding() *schema.Resource {
 func resourceServiceAccountBindingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	namespace := d.Get("organization").(string)
 	serviceAccountName := d.Get("service_account_name").(string)
-	poolMemberName := d.Get("pool_member_name").(string)
-	poolMemberNamespace := d.Get("pool_member_namespace").(string)
+	clusterName := d.Get("cluster_name").(string)
+
 	clientSet, err := getClientSet(getFactoryFromMeta(meta))
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("ERROR_INIT_CLIENT_ON_CREATE_SERVICE_ACCOUNT_BINDING: %w", err))
 	}
+
+	pulsarCluster, err := clientSet.CloudV1alpha1().PulsarClusters(namespace).Get(ctx, clusterName, metav1.GetOptions{})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("ERROR_READ_PULSAR_CLUSTER: %w", err))
+	}
+
+	poolMemberNamespace := pulsarCluster.Spec.PoolMemberRef.Namespace
+	poolMemberName := pulsarCluster.Spec.PoolMemberRef.Name
+
 	name := fmt.Sprintf("%s.%s.%s", serviceAccountName, poolMemberNamespace, poolMemberName)
 	sab := &v1alpha1.ServiceAccountBinding{
 		TypeMeta: metav1.TypeMeta{

--- a/docs/data-sources/pulsar_instance.md
+++ b/docs/data-sources/pulsar_instance.md
@@ -24,6 +24,8 @@ description: |-
 
 - `availability_mode` (String) The availability mode, supporting 'zonal' and 'regional'
 - `id` (String) The ID of this resource.
+- `oauth2_audience` (String) The audience of the oauth2
+- `oauth2_issuer_url` (String) The issuer url of the oauth2
 - `pool_name` (String) The infrastructure pool name
 - `pool_namespace` (String) The infrastructure pool namespace
 - `ready` (String) Pulsar instance is ready, it will be set to 'True' after the instance is ready

--- a/docs/resources/cloud_environment.md
+++ b/docs/resources/cloud_environment.md
@@ -40,10 +40,7 @@ description: |-
 Optional:
 
 - `cidr` (String)
-
-Read-Only:
-
-- `id` (String) The ID of this resource.
+- `id` (String)
 
 
 <a id="nestedblock--default_gateway"></a>

--- a/docs/resources/service_account_binding.md
+++ b/docs/resources/service_account_binding.md
@@ -17,12 +17,13 @@ description: |-
 
 ### Required
 
+- `cluster_name` (String) The pulsar cluster name
 - `organization` (String) The organization name
-- `pool_member_name` (String) The infrastructure pool member name
-- `pool_member_namespace` (String) The infrastructure pool member namespace
 - `service_account_name` (String) The service account name
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `name` (String) The service account binding name
+- `pool_member_name` (String) The infrastructure pool member name
+- `pool_member_namespace` (String) The infrastructure pool member namespace

--- a/examples/serviceaccountbindings/main.tf
+++ b/examples/serviceaccountbindings/main.tf
@@ -32,8 +32,7 @@ provider "streamnative" {
 resource "streamnative_service_account_binding" "func-runner" {
   organization = "sndev"
   service_account_name = "func-runner"
-  pool_member_name = "azure-westus3-dugong-snc"
-  pool_member_namespace = "streamnative"
+  cluster_name = "cluster"
 }
 
 data "streamnative_service_account_binding" "func-runner" {


### PR DESCRIPTION
- provide pulsar cluster to `ServiceAccountBinding` instead of poolmember info
- expose oauth2 status to `PulsarInstance`