### PR TITLE
Extend Default Timeout

### DIFF
--- a/cloud/resource_cloud_environment.go
+++ b/cloud/resource_cloud_environment.go
@@ -150,8 +150,8 @@ func resourceCloudEnvironment() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(60 * time.Minute),
+			Create: schema.DefaultTimeout(120 * time.Minute),
+			Delete: schema.DefaultTimeout(120 * time.Minute),
 		},
 	}
 }


### PR DESCRIPTION
The default of 1 hour is often too short