### PR TITLE
fix: Allow default_gateway to be null when passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-dev: build
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${PKG_NAME}/${VERSION}/${OS_ARCH}
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v -count 3 $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v -count 1 $(TESTARGS) -timeout 120m
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/cloud/apikey_test.go
+++ b/cloud/apikey_test.go
@@ -28,9 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var apiKeyGeneratedName = fmt.Sprintf("terraform-test-api-key-%d", rand.Intn(10000))
-
 func TestApiKey(t *testing.T) {
+	var apiKeyGeneratedName = fmt.Sprintf("terraform-test-api-key-%d", rand.Intn(10000))
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,

--- a/cloud/apikey_test.go
+++ b/cloud/apikey_test.go
@@ -28,8 +28,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var apiKeyGeneratedName = fmt.Sprintf("terraform-test-api-key-%d", rand.Intn(10000))
+
 func TestApiKey(t *testing.T) {
-	var apiKeyGeneratedName = fmt.Sprintf("terraform-test-api-key-%d", rand.Intn(10000))
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,

--- a/cloud/pulsar_cluster_test.go
+++ b/cloud/pulsar_cluster_test.go
@@ -54,7 +54,7 @@ func TestPulsarCluster(t *testing.T) {
 }
 
 func testCheckPulsarClusterDestroy(s *terraform.State) error {
-	time.Sleep(10 * time.Second)
+	time.Sleep(30 * time.Second)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "streamnative_pulsar_cluster" {
 			continue

--- a/cloud/resource_cloud_environment.go
+++ b/cloud/resource_cloud_environment.go
@@ -112,14 +112,18 @@ func resourceCloudEnvironment() *schema.Resource {
 				},
 			},
 			"default_gateway": {
-				Type:        schema.TypeList,
+				Type: schema.TypeList,
+				//Set this as optional and computed because an empty block will still create a default on the API and in the statefile
+				//As per https://github.com/hashicorp/terraform/issues/21278 Setting both allows optionally passing the config
 				Optional:    true,
+				Computed:    true,
 				Description: descriptions["default_gateway"],
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"access": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: descriptions["default_gateway_access"],
 						},
 						"private_service": {


### PR DESCRIPTION
<img width="985" alt="Screenshot 2024-09-16 at 8 32 25 AM" src="https://github.com/user-attachments/assets/9dd9e9d1-4b88-432b-a103-e3529ce46aa8">
On a basic apply without specifying the `default_gateway`, the next time a plan is run, Terraform wants to null the default_gateway. In order to make this a truly optional param, we can set the type as computed & optional. This tells Terraform that if it's not provided then compute the param, otherwise use the provided value

After change:
<img width="1172" alt="Screenshot 2024-09-16 at 9 24 34 AM" src="https://github.com/user-attachments/assets/37d1130a-9974-4cf5-8d98-b96468ae8e3e">

