### PR TITLE
build: unify build os and arch align with cli

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,18 +31,12 @@ builds:
     ldflags:
       - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
     goos:
-      - freebsd
       - windows
       - linux
       - darwin
     goarch:
       - amd64
-      - '386'
-      - arm
       - arm64
-    ignore:
-      - goos: darwin
-        goarch: '386'
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip


### PR DESCRIPTION
## Motivation
Unify the build os and arch for terraform-provider-streamnative and snctl.