### PR TITLE
Update layout to properly parse expiration_time string

### DIFF
--- a/cloud/resource_apikey.go
+++ b/cloud/resource_apikey.go
@@ -180,7 +180,7 @@ func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 			}
 			t = t.Add(ago)
 		} else if expirationTime != "0" {
-			layout := time.RFC3339[:len(expirationTime)]
+			layout := "2006-01-02T15:04:05Z07:00"
 			t, err = time.Parse(layout, expirationTime)
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("ERROR_PARSE_EXPIRATION_TIME: %w", err))

--- a/cloud/resource_apikey.go
+++ b/cloud/resource_apikey.go
@@ -171,6 +171,7 @@ func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 	r1 := regexp.MustCompile(`^(\d+.)(s|m|h|d)$`)
 	t := time.Now()
+
 	if expirationTime != "" {
 		if r1.MatchString(expirationTime) {
 			ago, err := str2duration.ParseDuration(expirationTime)
@@ -179,7 +180,7 @@ func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 			}
 			t = t.Add(ago)
 		} else if expirationTime != "0" {
-			layout := "2006-02-01T15:04:05Z"
+			layout := time.RFC3339[:len(expirationTime)]
 			t, err = time.Parse(layout, expirationTime)
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("ERROR_PARSE_EXPIRATION_TIME: %w", err))

--- a/cloud/resource_apikey.go
+++ b/cloud/resource_apikey.go
@@ -171,7 +171,6 @@ func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 	r1 := regexp.MustCompile(`^(\d+.)(s|m|h|d)$`)
 	t := time.Now()
-
 	if expirationTime != "" {
 		if r1.MatchString(expirationTime) {
 			ago, err := str2duration.ParseDuration(expirationTime)

--- a/cloud/resource_apikey.go
+++ b/cloud/resource_apikey.go
@@ -180,7 +180,7 @@ func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 			}
 			t = t.Add(ago)
 		} else if expirationTime != "0" {
-			layout := "2006-01-02T15:04:05Z07:00"
+			layout := "2006-01-02T15:04:05Z"
 			t, err = time.Parse(layout, expirationTime)
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("ERROR_PARSE_EXPIRATION_TIME: %w", err))


### PR DESCRIPTION
closes: #101 

The reference time "layout" var is incorrect and should have a different format:
```
layout := "2006-01-02T15:04:05Z07:00"
```

The 01 and 02 denote where the month and day string are located