### PR TITLE
fix Bookeeper npe

### DIFF
--- a/cloud/resource_pulsar_cluster.go
+++ b/cloud/resource_pulsar_cluster.go
@@ -962,7 +962,7 @@ func convertCpuAndMemoryToComputeUnit(pc *cloudv1alpha1.PulsarCluster) float64 {
 }
 
 func convertCpuAndMemoryToStorageUnit(pc *cloudv1alpha1.PulsarCluster) float64 {
-	if pc != nil && pc.Spec.BookKeeper.Resources != nil {
+	if pc != nil && pc.Spec.BookKeeper != nil && pc.Spec.BookKeeper.Resources != nil {
 		cpu := pc.Spec.BookKeeper.Resources.Cpu.MilliValue()
 		memory := pc.Spec.BookKeeper.Resources.Memory.Value()
 		return math.Max(float64(cpu)/2/1000, float64(memory)/(8*1024*1024*1024))


### PR DESCRIPTION
```
$ terraform import streamnative_pulsar_cluster.test-ursa max/fdl-ursa
streamnative_pulsar_cluster.test-ursa: Importing from ID "max/fdl-ursa"...
data.streamnative_pulsar_instance.test-ursa: Reading...
data.streamnative_pulsar_instance.test-ursa: Read complete after 1s [id=max/fdl-ursa]
╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin.(*GRPCProvider).ImportResourceState call. The plugin logs may contain more details.
╵


Stack trace from the terraform-provider-streamnative_v0.9.2 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x1048162a0]

goroutine 181 [running]:
github.com/streamnative/terraform-provider-streamnative/cloud.convertCpuAndMemoryToStorageUnit(0x140003b2908?)
        github.com/streamnative/terraform-provider-streamnative/cloud/resource_pulsar_cluster.go:965 +0x20
github.com/streamnative/terraform-provider-streamnative/cloud.resourcePulsarClusterRead({0x105540168, 0x14000cd1200}, 0x1400028e680, {0x10537f9e0, 0x14000f16480})
        github.com/streamnative/terraform-provider-streamnative/cloud/resource_pulsar_cluster.go:635 +0x186c
github.com/streamnative/terraform-provider-streamnative/cloud.resourcePulsarCluster.func2({0x105540168?, 0x14000cd1200?}, 0x1400028e680, {0x10537f9e0?, 0x14000f16480?})
        github.com/streamnative/terraform-provider-streamnative/cloud/resource_pulsar_cluster.go:60 +0x30
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).ImportState(0x14000864fc0, {0x105540168, 0x14000cd1200}, 0x14000d995d8, {0x14000f0d380, 0xc})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.28.0/helper/schema/provider.go:388 +0x12c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ImportResourceState(0x14000c81248, {0x105540168?, 0x14000cd1140?}, 0x14000b39020)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.28.0/helper/schema/grpc_provider.go:1097 +0xa4
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ImportResourceState(0x140006d60a0, {0x105540168?, 0x14000cd0870?}, 0x1400017ad70)
        github.com/hashicorp/terraform-plugin-go@v0.18.0/tfprotov5/tf5server/server.go:851 +0x188
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ImportResourceState_Handler({0x10539e260, 0x140006d60a0}, {0x105540168, 0x14000cd0870}, 0x1400028c9a0, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.18.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:440 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000b441e0, {0x10554eee0, 0x1400014e000}, 0x14000292a20, 0x140006247b0, 0x106d562b8, 0x0)
        google.golang.org/grpc@v1.64.1/server.go:1335 +0xb90
google.golang.org/grpc.(*Server).handleStream(0x14000b441e0, {0x10554eee0, 0x1400014e000}, 0x14000292a20, 0x0)
        google.golang.org/grpc@v1.64.1/server.go:1712 +0x7ac
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        google.golang.org/grpc@v1.64.1/server.go:947 +0xb4
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 47
        google.golang.org/grpc@v1.64.1/server.go:958 +0x14c

Error: The terraform-provider-streamnative_v0.9.2 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```