### PR TITLE
Use same read logic in APIKEY & set instance_name to the proper type

### DIFF
--- a/cloud/data_source_pulsar_cluster.go
+++ b/cloud/data_source_pulsar_cluster.go
@@ -62,7 +62,7 @@ func dataSourcePulsarCluster() *schema.Resource {
 			},
 			"instance_name": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Computed:    true,
 				Description: descriptions["instance_name"],
 			},
 			"location": {
@@ -268,7 +268,6 @@ func dataSourcePulsarCluster() *schema.Resource {
 func dataSourcePulsarClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	namespace := d.Get("organization").(string)
 	name := d.Get("name").(string)
-	instanceName := d.Get("instance_name").(string)
 	clientSet, err := getClientSet(getFactoryFromMeta(meta))
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("ERROR_INIT_CLIENT_ON_READ_PULSAR_CLUSTER: %w", err))
@@ -368,9 +367,7 @@ func dataSourcePulsarClusterRead(ctx context.Context, d *schema.ResourceData, me
 		_ = d.Set("release_channel", releaseChannel)
 	}
 
-	if instanceName != "" {
-		_ = d.Set("instance_name", instanceName)
-	}
+	_ = d.Set("instance_name", pulsarInstance.Name)
 	d.SetId(fmt.Sprintf("%s/%s", pulsarCluster.Namespace, pulsarCluster.Name))
 	return nil
 }

--- a/cloud/data_source_pulsar_cluster.go
+++ b/cloud/data_source_pulsar_cluster.go
@@ -62,8 +62,8 @@ func dataSourcePulsarCluster() *schema.Resource {
 			},
 			"instance_name": {
 				Type:        schema.TypeString,
+				Required:    true,
 				Description: descriptions["instance_name"],
-				Computed:    true,
 			},
 			"location": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
instance_name needs to be set to the remote resource value
Use the same read logic for api key resource and data 

```
resource "streamnative_pulsar_cluster" "test" {
  name = "test"
  organization = "xxx"
  instance_name = "test"
  location = "us-central1"
}

resource "streamnative_apikey" "key" {
  instance_name = "test"
  name = "test55"
  organization = "xxx"
  service_account_name = "test"
}

resource "streamnative_apikey" "key2" {
  instance_name = "test"
  name = "${streamnative_apikey.key.token}"
  organization = "xxx"
  service_account_name = "test"
}

data "streamnative_pulsar_cluster" "cluster" {
  name = "test"
  organization = "sndev"
}

output "instance" {
  value = data.streamnative_pulsar_cluster.cluster.instance_name
}

output "token" {
  value = streamnative_apikey.key.token
  sensitive = true
}
```

```
streamnative_apikey.key2: Creation complete after 1s [id=xxx/eyJhbGciOiJSUzI1NiIsImtpZCI6IjgxMzJhMmNmLWZhYTMtNTljMy1iNjIyLWM3MjNiNWRlOWE4NiIsInR5cCI6IkpXVCJ9.REDACTED]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

instance = "test"
token = <sensitive>
```

Token used in name above to validate value