### PR TITLE
Support principal name for apikey

### DIFF
--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -182,6 +182,7 @@ func init() {
 		"rolebinding_condition_resource_names_topic_domain": "The conditional role binding resource name - topic domain(persistent/non-persistent)",
 		"rolebinding_condition_resource_names_topic_name":   "The conditional role binding resource name - topic name",
 		"rolebinding_condition_resource_names_subscription": "The conditional role binding resource name - subscription",
+		"principal_name": "The principal name of apikey, it is the principal name of the service account that the apikey is associated with, it is used to grant permission on pulsar side",
 	}
 }
 

--- a/cloud/resource_apikey.go
+++ b/cloud/resource_apikey.go
@@ -359,5 +359,5 @@ func resourceApiKeyRead(ctx context.Context, d *schema.ResourceData, m interface
 		}
 	}
 	d.SetId(fmt.Sprintf("%s/%s", apiKey.Namespace, apiKey.Name))
-	return nil
+	return setPrincipalName(apiKey, d)
 }

--- a/cloud/resource_apikey.go
+++ b/cloud/resource_apikey.go
@@ -143,6 +143,11 @@ func resourceApiKey() *schema.Resource {
 				Computed:    true,
 				Description: descriptions["revoked_at"],
 			},
+			"principal_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: descriptions["principal_name"],
+			},
 		},
 	}
 }

--- a/docs/data-sources/apikey.md
+++ b/docs/data-sources/apikey.md
@@ -22,7 +22,7 @@ description: |-
 
 ### Optional
 
-- `private_key` (String) The private key for decrypting the encrypted token
+- `private_key` (String, Sensitive) The private key for decrypting the encrypted token
 
 ### Read-Only
 
@@ -32,7 +32,8 @@ description: |-
 - `instance_name` (String) The pulsar instance name
 - `issued_at` (String) The timestamp of when the key was issued, stored as an epoch in seconds
 - `key_id` (String) The key id of apikey
+- `principal_name` (String) The principal name of apikey, it is the principal name of the service account that the apikey is associated with, it is used to grant permission on pulsar side
 - `ready` (String) Apikey is ready, it will be set to 'True' after the api key is ready
 - `revoked_at` (String) The timestamp of when the key was revoked
 - `service_account_name` (String) The service account name
-- `token` (String) The token of the api key
+- `token` (String, Sensitive) The token of the api key

--- a/docs/resources/apikey.md
+++ b/docs/resources/apikey.md
@@ -34,6 +34,8 @@ description: |-
 - `id` (String) The ID of this resource.
 - `issued_at` (String) The timestamp of when the key was issued, stored as an epoch in seconds
 - `key_id` (String) The key id of apikey
-- `private_key` (String) The private key for decrypting the encrypted token
+- `principal_name` (String) The principal name of apikey, it is the principal name of the service account that the apikey is associated with, it is used to grant permission on pulsar side
+- `private_key` (String, Sensitive) The private key for decrypting the encrypted token
 - `ready` (String) Apikey is ready, it will be set to 'True' after the api key is ready
 - `revoked_at` (String) The timestamp of when the key was revoked
+- `token` (String, Sensitive) The token of the api key

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -23,8 +23,17 @@ description: |-
 ### Optional
 
 - `admin` (Boolean) Whether the service account is admin
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `private_key_data` (String) The private key data
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+- `delete` (String)


### PR DESCRIPTION

How to use it:

```
provider "pulsar" {
  web_service_url = "http://localhost:8080"
}

resource "pulsar_tenant" "my_tenant" {
  tenant           = "thanos"
  allowed_clusters = ["pulsar-cluster-1"]
  admin_roles      = [data.streamnative_apikey.test-admin-a. principal_name]
}
```