### PR TITLE
fix: validate rolebinding import ID format to prevent panic

### DIFF
--- a/cloud/resource_rolebinding.go
+++ b/cloud/resource_rolebinding.go
@@ -40,6 +40,9 @@ func resourceRoleBinding() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				organizationRoleBinding := strings.Split(d.Id(), "/")
+				if len(organizationRoleBinding) != 2 {
+					return nil, fmt.Errorf("invalid rolebinding import ID format: %q. Expected format: 'organization/name'", d.Id())
+				}
 				if err := d.Set("organization", organizationRoleBinding[0]); err != nil {
 					return nil, fmt.Errorf("ERROR_IMPORT_ORGANIZATION: %w", err)
 				}


### PR DESCRIPTION
The import function was incorrectly assuming the ID would always contain a '/' separator, causing an index out of range panic when users tried to import with IDs that didn't match the expected 'organization/name' format.

This fix adds validation to check the ID format and provide a clear error message instead of panicking.

Fixes streamnative/eng-support-tickets#3160