### PR TITLE
feat: Add additional_tags to CE logic

### DIFF
--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -169,6 +169,7 @@ func init() {
 		"oauth2_issuer_url":                    "The issuer url of the oauth2",
 		"oauth2_audience":                      "The audience of the oauth2",
 		"annotations":                          "The metadata annotations of the resource",
+		"additional_tags":                       "Additional tags to apply to the cloud environment as annotations with the prefix cloud.streamnative.io/environment-parameter-",
 		"rolebinding_ready":                    "The RoleBinding is ready, it will be set to 'True' after the cluster is ready",
 		"rolebinding_name":                     "The name of rolebinding",
 		"rolebinding_cluster_role_name":        "The predefined role name",

--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -169,7 +169,7 @@ func init() {
 		"oauth2_issuer_url":                    "The issuer url of the oauth2",
 		"oauth2_audience":                      "The audience of the oauth2",
 		"annotations":                          "The metadata annotations of the resource",
-		"additional_tags":                       "Additional tags to apply to the cloud environment as annotations with the prefix cloud.streamnative.io/environment-parameter-",
+		"additional_tags":                      "Additional tags to apply to the cloud environment as annotations with the prefix cloud.streamnative.io/environment-parameter-",
 		"rolebinding_ready":                    "The RoleBinding is ready, it will be set to 'True' after the cluster is ready",
 		"rolebinding_name":                     "The name of rolebinding",
 		"rolebinding_cluster_role_name":        "The predefined role name",

--- a/cloud/provider.go
+++ b/cloud/provider.go
@@ -169,7 +169,7 @@ func init() {
 		"oauth2_issuer_url":                    "The issuer url of the oauth2",
 		"oauth2_audience":                      "The audience of the oauth2",
 		"annotations":                          "The metadata annotations of the resource",
-		"additional_tags":                      "Additional tags to apply to the cloud environment as annotations with the prefix cloud.streamnative.io/environment-parameter-",
+		"additional_tags":                      "Additional tags to apply to the cloud environment; stored as JSON in the annotation cloud.streamnative.io/environment-parameter-additional_tags",
 		"rolebinding_ready":                    "The RoleBinding is ready, it will be set to 'True' after the cluster is ready",
 		"rolebinding_name":                     "The name of rolebinding",
 		"rolebinding_cluster_role_name":        "The predefined role name",

--- a/cloud/resource_cloud_environment.go
+++ b/cloud/resource_cloud_environment.go
@@ -404,11 +404,15 @@ func resourceCloudEnvironmentRead(ctx context.Context, d *schema.ResourceData, m
 		_ = d.Set("default_gateway", flattenDefaultGateway(cloudEnvironment.Spec.DefaultGateway))
 	}
 
-	if raw, ok := cloudEnvironment.Annotations["cloud.streamnative.io/environment-parameter-additional_tags"]; ok && raw != "" {
+	raw, ok := cloudEnvironment.Annotations["cloud.streamnative.io/environment-parameter-additional_tags"]
+	if !ok || raw == "" {
+		_ = d.Set("additional_tags", map[string]string{})
+	} else {
 		additionalTags := make(map[string]string)
-		if err := json.Unmarshal([]byte(raw), &additionalTags); err == nil {
-			_ = d.Set("additional_tags", additionalTags)
+		if err := json.Unmarshal([]byte(raw), &additionalTags); err != nil {
+			return diag.FromErr(fmt.Errorf("ERROR_READ_CLOUD_ENVIRONMENT: failed to deserialize additional_tags annotation: %w", err))
 		}
+		_ = d.Set("additional_tags", additionalTags)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", cloudEnvironment.Namespace, cloudEnvironment.Name))

--- a/cloud/resource_cloud_environment.go
+++ b/cloud/resource_cloud_environment.go
@@ -16,6 +16,7 @@ package cloud
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -190,6 +191,12 @@ func resourceCloudEnvironment() *schema.Resource {
 				Elem:         &schema.Schema{Type: schema.TypeString},
 				ValidateFunc: validateAnnotations,
 			},
+			"additional_tags": {
+				Type:        schema.TypeMap,
+				Description: descriptions["additional_tags"],
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"wait_for_completion": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -230,6 +237,15 @@ func resourceCloudEnvironmentCreate(ctx context.Context, d *schema.ResourceData,
 		annotations = convertToStringMap(rawAnnotations)
 	}
 	annotations["cloud.streamnative.io/environment-type"] = cloudEnvironmentType
+
+	rawAdditionalTags := d.Get("additional_tags").(map[string]interface{})
+	if len(rawAdditionalTags) > 0 {
+		tagsJSON, err := json.Marshal(convertToStringMap(rawAdditionalTags))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("ERROR_CREATE_CLOUD_ENVIRONMENT: failed to serialize additional_tags: %w", err))
+		}
+		annotations["cloud.streamnative.io/environment-parameter-additional_tags"] = string(tagsJSON)
+	}
 
 	if cc.Spec.ConnectionType != cloudv1alpha1.ConnectionTypeAzure {
 		if !contains(validRegions, region) {
@@ -388,6 +404,13 @@ func resourceCloudEnvironmentRead(ctx context.Context, d *schema.ResourceData, m
 		_ = d.Set("default_gateway", flattenDefaultGateway(cloudEnvironment.Spec.DefaultGateway))
 	}
 
+	if raw, ok := cloudEnvironment.Annotations["cloud.streamnative.io/environment-parameter-additional_tags"]; ok && raw != "" {
+		additionalTags := make(map[string]string)
+		if err := json.Unmarshal([]byte(raw), &additionalTags); err == nil {
+			_ = d.Set("additional_tags", additionalTags)
+		}
+	}
+
 	d.SetId(fmt.Sprintf("%s/%s", cloudEnvironment.Namespace, cloudEnvironment.Name))
 	return nil
 }
@@ -427,6 +450,22 @@ func resourceCloudEnvironmentUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	cloudEnvironment.Spec.DefaultGateway = convertGateway(d.Get("default_gateway"))
+
+	if d.HasChange("additional_tags") {
+		if cloudEnvironment.Annotations == nil {
+			cloudEnvironment.Annotations = make(map[string]string)
+		}
+		rawAdditionalTags := d.Get("additional_tags").(map[string]interface{})
+		if len(rawAdditionalTags) > 0 {
+			tagsJSON, err := json.Marshal(convertToStringMap(rawAdditionalTags))
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("ERROR_UPDATE_CLOUD_ENVIRONMENT: failed to serialize additional_tags: %w", err))
+			}
+			cloudEnvironment.Annotations["cloud.streamnative.io/environment-parameter-additional_tags"] = string(tagsJSON)
+		} else {
+			delete(cloudEnvironment.Annotations, "cloud.streamnative.io/environment-parameter-additional_tags")
+		}
+	}
 
 	if _, err := clientSet.CloudV1alpha1().CloudEnvironments(namespace).Update(ctx, cloudEnvironment, metav1.UpdateOptions{
 		FieldManager: "terraform-update",


### PR DESCRIPTION
## Summary

Adds `additional_tags` support to the `streamnative_cloud_environment` resource.

- New optional `additional_tags` field (TypeMap of string) on the `streamnative_cloud_environment` resource
- On create/update, the map is JSON-serialized and stored as a single annotation: `cloud.streamnative.io/environment-parameter-additional_tags`
- On read, the annotation is deserialized back into state
- On update, the annotation is replaced when the field changes, and removed when set to empty

## Example usage

```hcl
resource "streamnative_cloud_environment" "example" {
  organization          = "o-example"
  region                = "us-east-1"
  cloud_connection_name = "my-connection"
  network {
    cidr = "10.0.0.0/16"
  }
  additional_tags = {
    test  = "test"
  }
}
```

This produces the annotation:

`cloud.streamnative.io/environment-parameter-additional_tags: {"test":"test"}`

<img width="711" height="196" alt="Screenshot 2026-06-03 at 4 21 50 PM" src="https://github.com/user-attachments/assets/b0209789-d2e0-41fe-bc38-6c5dc3b8a418" />
