### PR TITLE
docs: correct maintenance_window recurrence weekday mapping (0 = Sunday)

### DIFF
--- a/cloud/data_source_pulsar_cluster.go
+++ b/cloud/data_source_pulsar_cluster.go
@@ -316,7 +316,7 @@ func dataSourcePulsarCluster() *schema.Resource {
 						"recurrence": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "Recurrence pattern for maintenance (0-6 for Monday to Sunday)",
+							Description: "Recurrence pattern for maintenance: comma-separated weekday integers where 0 = Sunday and 6 = Saturday (e.g. \"0,6\" means Sunday and Saturday)",
 						},
 					},
 				},

--- a/cloud/resource_pulsar_cluster.go
+++ b/cloud/resource_pulsar_cluster.go
@@ -410,7 +410,7 @@ func resourcePulsarCluster() *schema.Resource {
 						"recurrence": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Recurrence pattern for maintenance (0-6 for Monday to Sunday)",
+							Description: "Recurrence pattern for maintenance: comma-separated weekday integers where 0 = Sunday and 6 = Saturday (e.g. \"0,6\" means Sunday and Saturday)",
 						},
 					},
 				},

--- a/docs/resources/pulsar_cluster.md
+++ b/docs/resources/pulsar_cluster.md
@@ -104,7 +104,7 @@ Optional:
 
 Optional:
 
-- `recurrence` (String) Recurrence pattern for maintenance (0-6 for Monday to Sunday)
+- `recurrence` (String) Recurrence pattern for maintenance: comma-separated weekday integers where 0 = Sunday and 6 = Saturday (e.g. "0,6" means Sunday and Saturday)
 - `window` (Block List) Maintenance execution window (see [below for nested schema](#nestedblock--maintenance_window--window))
 
 <a id="nestedblock--maintenance_window--window"></a>


### PR DESCRIPTION
## What

Fix the `maintenance_window.recurrence` weekday-mapping description on both the `streamnative_pulsar_cluster` resource and data source, and regenerate the docs.

- Old: `Recurrence pattern for maintenance (0-6 for Monday to Sunday)` → implies **0 = Monday**
- New: `Recurrence pattern for maintenance: comma-separated weekday integers where 0 = Sunday and 6 = Saturday (e.g. "0,6" means Sunday and Saturday)`

## Why

The integer→weekday mapping was inconsistent across surfaces: the Terraform schema/docs and `kubectl explain` claimed `0 = Monday`, while the cloud console renders and schedules `0 = Sunday`.

The authoritative behavior was verified against the cloud console scheduler source: it compares the recurrence integer directly against dayjs `.day()`, which is **0 = Sunday … 6 = Saturday** (same convention as Go's `time.Weekday`). So the provider/CRD docs were stale, not the console.

## Scope

- **Doc-only.** The provider never parses `recurrence` — it round-trips as an opaque `schema.TypeString` through `expand/flattenMaintenanceWindow`. No logic change.
- `docs/resources/pulsar_cluster.md` regenerated via `tfplugindocs` (only the one line changed).
- The data-source description is updated for source consistency; `tfplugindocs` does not render descriptions for read-only nested attributes, so `docs/data-sources/pulsar_cluster.md` is unchanged.

## Out of scope (cloud team follow-up)

The CRD field comment (`cloud-api-server` `pulsarcluster_types.go`) and `kubectl explain` carry the same stale `0~6, Monday to Sunday` text and should be corrected separately.

## Verification

- `gofmt -l` clean; `go build ./...` succeeds.
- `git diff docs/` shows only the single expected line change, no other drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)